### PR TITLE
Feature/add multiple

### DIFF
--- a/contracts/Compensation.sol
+++ b/contracts/Compensation.sol
@@ -329,7 +329,6 @@ contract Compensation is Ownable {
         address _address,
         uint256 _totalCompensationAmount
     ) public onlyOwner {
-        require(tokenClaimLimit[_address] == 0, "Address has already been added for compensation.");
         tokenClaimLimit[_address] = _totalCompensationAmount;
     }
 
@@ -345,7 +344,6 @@ contract Compensation is Ownable {
         require(_addresses.length == _totalCompensationAmounts.length, "Length of 2 arrays must be the same.");
         uint8 i = 0;
         for (i; i < _addresses.length; i++) {
-            require(tokenClaimLimit[_addresses[i]] == 0, "Address has already been added for compensation.");
             tokenClaimLimit[_addresses[i]] = _totalCompensationAmounts[i];
         }
     } 

--- a/contracts/Compensation.sol
+++ b/contracts/Compensation.sol
@@ -329,8 +329,26 @@ contract Compensation is Ownable {
         address _address,
         uint256 _totalCompensationAmount
     ) public onlyOwner {
+        require(tokenClaimLimit[_address] == 0, "Address has already been added for compensation.");
         tokenClaimLimit[_address] = _totalCompensationAmount;
     }
+
+    /**
+     * @dev adds multiple addresses for compensation
+     * @param _addresses array of address is the addresses to be compensated
+     * @param _totalCompensationAmounts array of uint256 is the total amounts of tokens claimable by these addresses
+     */
+    function addMultipleAddressesforCompensation(
+        address[] memory _addresses,
+        uint256[] memory _totalCompensationAmounts
+    ) public onlyOwner {
+        require(_addresses.length == _totalCompensationAmounts.length, "Length of 2 arrays must be the same.");
+        uint8 i = 0;
+        for (i; i < _addresses.length; i++) {
+            require(tokenClaimLimit[_addresses[i]] == 0, "Address has already been added for compensation.");
+            tokenClaimLimit[_addresses[i]] = _totalCompensationAmounts[i];
+        }
+    } 
 
     /**
      * @dev enables claims of available tokens as compensation

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,13 +1,23 @@
 const Compensation = artifacts.require("Compensation");
 const Token = artifacts.require("Token");
 
-module.exports = function(deployer) {
+module.exports = function (deployer) {
   deployer.then(async () => {
     // Deploy reimbursement token for testing
     const totalTokenSupply = 10000000000;
-    const token = await deployer.deploy(Token, "Test Token", "TEST", totalTokenSupply);
+    const token = await deployer.deploy(
+      Token,
+      "Test Token",
+      "TEST",
+      totalTokenSupply
+    );
 
     // Deploy compensation contract
-    deployer.deploy(Compensation, token.address);
+    deployer.deploy(
+      Compensation,
+      token.address,
+      "1100000000000000000000000",
+      10
+    );
   });
 };


### PR DESCRIPTION
Added `addMultipleAddressesforCompensation`
Removed `require(tokenClaimLimit[_addresses[i]] == 0, "Address has already been added for compensation.");` because we can override current claimLimit list if something is wrong.